### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ all: 2048 2048_no_curses
 
 2048_no_curses: 2048_no_curses.c
 	$(CC) $(CFLAGS) 2048_no_curses.c -o 2048_no_curses
+
+clean:
+	rm -f 2048 2048_no_curses


### PR DESCRIPTION
- Don't override user-set CC
- Use canonical variable name for C compiler flags
- Respect both all over the Makefile
- Add clean target for completeness
