### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "make && ./2048"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 2048-cli
 
+[![run on repl.it](http://repl.it/badge/github/tiehuis/2048-cli)](https://repl.it/github/tiehuis/2048-cli)
+
 A cli version/engine of the game [2048](https://github.com/gabrielecirulli/2048)=
 for your Linux terminal.
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-2048-cli):

![image](https://i.imgur.com/pirN2I5.png)